### PR TITLE
Add basic Breeze-style authentication scaffolding

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class AuthenticatedSessionController extends Controller
+{
+    public function create(): View
+    {
+        return view('auth.login');
+    }
+
+    public function store(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            $request->session()->regenerate();
+            return redirect()->intended('/dashboard');
+        }
+
+        return back()->withErrors([
+            'email' => __('auth.failed'),
+        ])->onlyInput('email');
+    }
+
+    public function destroy(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/');
+    }
+}

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class RegisteredUserController extends Controller
+{
+    public function create(): View
+    {
+        return view('auth.register');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'confirmed', 'min:8'],
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        Auth::login($user);
+
+        return redirect('/dashboard');
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class ProfileController extends Controller
+{
+    public function edit(): View
+    {
+        return view('profile.edit');
+    }
+
+    public function update(Request $request)
+    {
+        $user = $request->user();
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,' . $user->id],
+        ]);
+
+        $user->update($data);
+
+        return back()->with('status', 'profile-updated');
+    }
+
+    public function destroy(Request $request)
+    {
+        $request->user()->delete();
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.41",
+        "laravel/breeze": "^2.0",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "phpstan/phpstan": "^2.1",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('title', 'Вхід')
+
+@section('content')
+    <div class="container mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">Вхід</h1>
+        <form method="post" action="{{ route('login') }}">
+            @csrf
+            <div class="mb-4">
+                <label class="block mb-1" for="email">Email</label>
+                <input id="email" name="email" type="email" class="border p-2 w-full" required autofocus>
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1" for="password">Пароль</label>
+                <input id="password" name="password" type="password" class="border p-2 w-full" required>
+            </div>
+            <div class="mb-4">
+                <label><input type="checkbox" name="remember"> Запам'ятати мене</label>
+            </div>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Увійти</button>
+        </form>
+    </div>
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('title', 'Реєстрація')
+
+@section('content')
+    <div class="container mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">Реєстрація</h1>
+        <form method="post" action="{{ route('register') }}">
+            @csrf
+            <div class="mb-4">
+                <label class="block mb-1" for="name">Ім'я</label>
+                <input id="name" name="name" class="border p-2 w-full" required>
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1" for="email">Email</label>
+                <input id="email" name="email" type="email" class="border p-2 w-full" required>
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1" for="password">Пароль</label>
+                <input id="password" name="password" type="password" class="border p-2 w-full" required>
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1" for="password_confirmation">Підтвердіть пароль</label>
+                <input id="password_confirmation" name="password_confirmation" type="password" class="border p-2 w-full" required>
+            </div>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Зареєструватися</button>
+        </form>
+    </div>
+@endsection

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+
+@section('title', 'Мій кабінет')
+
+@section('content')
+    <div class="container mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">Вітаємо, {{ auth()->user()->name }}!</h1>
+        <p>Це ваш кабінет.</p>
+    </div>
+@endsection

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -34,6 +34,12 @@
                     ({{ $count }})
                 @endif
             </a>
+
+            @auth
+                <a href="{{ route('dashboard') }}">Мій кабінет</a>
+            @else
+                <a href="{{ route('login') }}">Обліковий запис</a>
+            @endauth
         </nav>
     </div>
 </header>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('title', 'Профіль')
+
+@section('content')
+    <div class="container mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">Профіль</h1>
+        <form method="post" action="{{ route('profile.update') }}">
+            @csrf
+            @method('patch')
+            <div class="mb-4">
+                <label class="block mb-1" for="name">Ім'я</label>
+                <input id="name" name="name" value="{{ old('name', auth()->user()->name) }}" class="border p-2 w-full">
+            </div>
+            <div class="mb-4">
+                <label class="block mb-1" for="email">Email</label>
+                <input id="email" name="email" value="{{ old('email', auth()->user()->email) }}" class="border p-2 w-full">
+            </div>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Зберегти</button>
+        </form>
+    </div>
+@endsection

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\RegisteredUserController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/register', [RegisteredUserController::class, 'create'])
+    ->middleware('guest')
+    ->name('register');
+
+Route::post('/register', [RegisteredUserController::class, 'store'])
+    ->middleware('guest');
+
+Route::get('/login', [AuthenticatedSessionController::class, 'create'])
+    ->middleware('guest')
+    ->name('login');
+
+Route::post('/login', [AuthenticatedSessionController::class, 'store'])
+    ->middleware('guest');
+
+Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+    ->middleware('auth')
+    ->name('logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,5 +30,15 @@ Route::view('/cart', 'pages.cart')->name('cart');
 Route::view('/checkout', 'pages.checkout')->name('checkout');
 Route::post('/order', [OrderController::class, 'store'])->name('order.store');
 
+// --- Кабінет користувача ---
+Route::middleware(['auth'])->group(function () {
+    Route::view('/dashboard', 'dashboard')->name('dashboard');
+    Route::get('/profile', [App\Http\Controllers\ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [App\Http\Controllers\ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [App\Http\Controllers\ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
 // --- SPA-адмінка ---
 Route::view('/admin/{any?}', 'layouts.admin_spa')->where('any', '.*');
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- include `laravel/breeze` in dev dependencies
- add authentication controllers and routes
- scaffold basic login, register, profile and dashboard views
- link to dashboard from the site header when authenticated

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847380883008330a7c44502475ec8b1