### PR TITLE
Add phone support for users

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -22,12 +22,14 @@ class RegisteredUserController extends Controller
         $data = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'phone' => ['nullable', 'string'],
             'password' => ['required', 'string', 'confirmed', 'min:8'],
         ]);
 
         $user = User::create([
             'name' => $data['name'],
             'email' => $data['email'],
+            'phone' => $data['phone'] ?? null,
             'password' => Hash::make($data['password']),
         ]);
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -30,7 +30,7 @@ class OrderController extends Controller
             'phone' => $data['phone'],
             'email' => $data['email'],
             'status' => 'Очікує підтвердження',
-            'user_id' => auth()->id(),
+            'user_id' => auth()->check() ? auth()->id() : null,
         ]);
 
         foreach ($cart as $productId => $item) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -21,6 +21,7 @@ class ProfileController extends Controller
         $data = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,' . $user->id],
+            'phone' => ['nullable', 'string'],
             'password' => ['nullable', 'string', 'confirmed', 'min:8'],
         ]);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'phone',
         'password',
         'is_admin',
     ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'phone' => fake()->phoneNumber(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_06_10_150000_add_phone_to_users_table.php
+++ b/database/migrations/2025_06_10_150000_add_phone_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('phone')->nullable()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('phone');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'phone' => '+380000000000',
         ]);
     }
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -27,6 +27,10 @@
                 <input id="email" name="email" type="email" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('email') }}" required>
             </div>
             <div class="mb-4">
+                <label class="block text-gray-700 text-sm font-bold mb-2" for="phone">Телефон</label>
+                <input id="phone" name="phone" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="{{ old('phone') }}">
+            </div>
+            <div class="mb-4">
                 <label class="block text-gray-700 text-sm font-bold mb-2" for="password">Пароль</label>
                 <input id="password" name="password" type="password" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" minlength="8" required>
             </div>

--- a/resources/views/pages/checkout.blade.php
+++ b/resources/views/pages/checkout.blade.php
@@ -7,15 +7,15 @@
             @csrf
             <div>
                 <label for="name" class="block font-medium mb-1">Ваше імʼя</label>
-                <input type="text" id="name" name="name" required class="w-full border px-3 py-2 rounded">
+                <input type="text" id="name" name="name" required class="w-full border px-3 py-2 rounded" value="{{ old('name', auth()->user()->name ?? '') }}">
             </div>
             <div>
                 <label for="phone" class="block font-medium mb-1">Телефон</label>
-                <input type="text" id="phone" name="phone" required class="w-full border px-3 py-2 rounded">
+                <input type="text" id="phone" name="phone" required class="w-full border px-3 py-2 rounded" value="{{ old('phone', auth()->user()->phone ?? '') }}">
             </div>
             <div>
                 <label for="email" class="block font-medium mb-1">Email</label>
-                <input type="email" id="email" name="email" class="w-full border px-3 py-2 rounded">
+                <input type="email" id="email" name="email" class="w-full border px-3 py-2 rounded" value="{{ old('email', auth()->user()->email ?? '') }}">
             </div>
             <button type="submit" class="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700">Оформити замовлення</button>
         </form>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -17,6 +17,10 @@
                 <input id="email" name="email" value="{{ old('email', auth()->user()->email) }}" class="border p-2 w-full">
             </div>
             <div class="mb-4">
+                <label class="block mb-1" for="phone">Телефон</label>
+                <input id="phone" name="phone" value="{{ old('phone', auth()->user()->phone) }}" class="border p-2 w-full">
+            </div>
+            <div class="mb-4">
                 <label class="block mb-1" for="password">Новий пароль</label>
                 <input id="password" name="password" type="password" class="border p-2 w-full">
             </div>


### PR DESCRIPTION
## Summary
- add phone column to users table
- allow phone fillable on `User`
- capture phone during registration and profile editing
- prefill checkout form with user data if available
- include user_id only when logged in for orders

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68487cd044f883308ec88b457e2decf7